### PR TITLE
給与計算に歩合などの手当を含める

### DIFF
--- a/api/cmd/seed.go
+++ b/api/cmd/seed.go
@@ -3,7 +3,6 @@ package main
 import (
 	"github.com/t2469/labor-management-system.git/config"
 	"github.com/t2469/labor-management-system.git/db"
-	"github.com/t2469/labor-management-system.git/models"
 	"github.com/t2469/labor-management-system.git/seed"
 	"log"
 	"time"
@@ -16,18 +15,7 @@ func main() {
 		panic(err)
 	}
 	time.Local = loc
-
 	db.InitDB()
-	if err := db.DB.AutoMigrate(
-		&models.Prefecture{},
-		&models.Company{},
-		&models.Employee{},
-		&models.Attendance{},
-		&models.HealthInsuranceRate{},
-		&models.PensionInsuranceRate{},
-	); err != nil {
-		log.Fatalf("failed to migrate database: %v", err)
-	}
 
 	if err := seed.SeedPrefectures(db.DB); err != nil {
 		log.Fatalf("seedPrefectures failed: %v", err)

--- a/api/controllers/allowance_controller.go
+++ b/api/controllers/allowance_controller.go
@@ -21,3 +21,18 @@ func CrateAllowanceType(c *gin.Context) {
 
 	c.JSON(http.StatusOK, at)
 }
+
+func CreateEmployeeAllowance(c *gin.Context) {
+	var ea models.EmployeeAllowance
+	if err := c.ShouldBindJSON(&ea); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if err := db.DB.Create(&ea).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, ea)
+}

--- a/api/controllers/allowance_controller.go
+++ b/api/controllers/allowance_controller.go
@@ -1,0 +1,23 @@
+package controllers
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/t2469/labor-management-system.git/db"
+	"github.com/t2469/labor-management-system.git/models"
+	"net/http"
+)
+
+func CrateAllowanceType(c *gin.Context) {
+	var at models.AllowanceType
+	if err := c.ShouldBindJSON(&at); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if err := db.DB.Create(&at).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, at)
+}

--- a/api/main.go
+++ b/api/main.go
@@ -26,6 +26,8 @@ func main() {
 		&models.Attendance{},
 		&models.HealthInsuranceRate{},
 		&models.PensionInsuranceRate{},
+		&models.AllowanceType{},
+		&models.EmployeeAllowance{},
 	); err != nil {
 		log.Fatalf("failed to migrate database: %v", err)
 	}

--- a/api/models/allowance_type.go
+++ b/api/models/allowance_type.go
@@ -1,0 +1,13 @@
+package models
+
+import "time"
+
+type AllowanceType struct {
+	ID             uint      `gorm:"primaryKey" json:"id"`
+	Name           string    `gorm:"unique;not null" json:"name"`
+	Type           string    `json:"type"` // "commission" or "fixed"
+	Description    string    `json:"description"`
+	CommissionRate float64   `json:"commission_rate"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}

--- a/api/models/employee.go
+++ b/api/models/employee.go
@@ -3,13 +3,14 @@ package models
 import "time"
 
 type Employee struct {
-	ID            uint         `gorm:"primaryKey" json:"id"`
-	CompanyID     uint         `json:"company_id"`
-	Company       Company      `json:"company" gorm:"foreignKey:CompanyID"`
-	Name          string       `json:"name"`
-	MonthlySalary int          `json:"monthly_salary"`
-	DateOfBirth   time.Time    `json:"date_of_birth"`
-	CreatedAt     time.Time    `json:"created_at"`
-	UpdatedAt     time.Time    `json:"updated_at"`
-	Attendances   []Attendance `json:"attendances,omitempty" gorm:"foreignKey:EmployeeID"`
+	ID            uint                `gorm:"primaryKey" json:"id"`
+	CompanyID     uint                `json:"company_id"`
+	Company       Company             `json:"company" gorm:"foreignKey:CompanyID"`
+	Name          string              `json:"name"`
+	MonthlySalary int                 `json:"monthly_salary"`
+	DateOfBirth   time.Time           `json:"date_of_birth"`
+	CreatedAt     time.Time           `json:"created_at"`
+	UpdatedAt     time.Time           `json:"updated_at"`
+	Attendances   []Attendance        `json:"attendances,omitempty" gorm:"foreignKey:EmployeeID"`
+	Allowances    []EmployeeAllowance `json:"allowances,omitempty" gorm:"foreignKey:EmployeeID"`
 }

--- a/api/models/employee_allowance.go
+++ b/api/models/employee_allowance.go
@@ -1,0 +1,14 @@
+package models
+
+import "time"
+
+type EmployeeAllowance struct {
+	ID              uint          `gorm:"primaryKey" json:"id"`
+	EmployeeID      uint          `json:"employee_id"`
+	AllowanceTypeID uint          `json:"allowance_type_id"`
+	Amount          int           `json:"amount"`
+	CommissionRate  float64       `json:"commission_rate,omitempty"`
+	CreatedAt       time.Time     `json:"created_at"`
+	UpdatedAt       time.Time     `json:"updated_at"`
+	AllowanceType   AllowanceType `json:"allowance_type" gorm:"foreignKey:AllowanceTypeID"`
+}

--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -38,6 +38,7 @@ func SetupRouter(cfg *config.Config) *gin.Engine {
 	allowances := router.Group("/allowances")
 	{
 		allowances.POST("type", controllers.CrateAllowanceType)
+		allowances.POST("", controllers.CreateEmployeeAllowance)
 	}
 	return router
 }

--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -35,6 +35,10 @@ func SetupRouter(cfg *config.Config) *gin.Engine {
 		companies.POST("", controllers.CreateCompany)
 	}
 
+	allowances := router.Group("/allowances")
+	{
+		allowances.POST("type", controllers.CrateAllowanceType)
+	}
 	return router
 }
 

--- a/api/services/payroll_service.go
+++ b/api/services/payroll_service.go
@@ -1,12 +1,14 @@
 package services
 
 import (
+	"github.com/t2469/labor-management-system.git/models"
 	"gorm.io/gorm"
 )
 
 type PayrollCalculationResponse struct {
 	EmployeeName    string  `json:"employee_name"`
-	GrossSalary     int     `json:"gross_salary"`
+	GrossSalary     float64 `json:"gross_salary"`
+	TotalAllowance  float64 `json:"total_allowance"`
 	HealthInsurance float64 `json:"health_insurance"`
 	Pension         float64 `json:"pension"`
 	TotalDeductions float64 `json:"total_deductions"`
@@ -14,7 +16,32 @@ type PayrollCalculationResponse struct {
 }
 
 func CalculatePayroll(db *gorm.DB, employeeID uint) (PayrollCalculationResponse, error) {
-	insuranceResp, err := CalculateInsurance(db, employeeID)
+	var emp models.Employee
+	if err := db.
+		Preload("Company.Prefecture.HealthInsuranceRates").
+		Preload("Company.Prefecture.PensionInsuranceRates").
+		Preload("Allowances.AllowanceType").
+		First(&emp, employeeID).Error; err != nil {
+		return PayrollCalculationResponse{}, err
+	}
+
+	var totalAllowance float64
+	for _, ea := range emp.Allowances {
+		switch ea.AllowanceType.Type {
+		case "commission":
+			// 従業員ごとに設定された割合があればそれを使い、なければ AllowanceType の値を使用
+			rate := ea.CommissionRate
+			if rate == 0 {
+				rate = ea.AllowanceType.CommissionRate
+			}
+			commissionAmount := float64(ea.Amount) * rate
+			totalAllowance += commissionAmount
+		case "fixed":
+			totalAllowance += float64(ea.Amount)
+		}
+	}
+
+	healthResp, err := CalculateInsurance(db, employeeID)
 	if err != nil {
 		return PayrollCalculationResponse{}, err
 	}
@@ -24,16 +51,20 @@ func CalculatePayroll(db *gorm.DB, employeeID uint) (PayrollCalculationResponse,
 		return PayrollCalculationResponse{}, err
 	}
 
-	grossSalary := insuranceResp.CalculatedMonthlyAmount
+	// 支給額(基本給+手当合計)
+	baseSalary := emp.MonthlySalary
+	grossSalary := float64(baseSalary) + totalAllowance
 
-	totalDeductions := insuranceResp.EmployeeHealth + pensionResp.EmployeePension
+	// 控除額(健康保険,介護保険,厚生年金)
+	totalDeductions := healthResp.EmployeeHealth + pensionResp.EmployeePension
 
-	netSalary := float64(grossSalary) - totalDeductions
+	// 手取り給与
+	netSalary := grossSalary - totalDeductions
 
 	resp := PayrollCalculationResponse{
-		EmployeeName:    insuranceResp.EmployeeName,
+		EmployeeName:    healthResp.EmployeeName,
 		GrossSalary:     grossSalary,
-		HealthInsurance: insuranceResp.EmployeeHealth,
+		HealthInsurance: healthResp.EmployeeHealth,
 		Pension:         pensionResp.EmployeePension,
 		TotalDeductions: totalDeductions,
 		NetSalary:       netSalary,

--- a/api/services/payroll_service.go
+++ b/api/services/payroll_service.go
@@ -64,6 +64,7 @@ func CalculatePayroll(db *gorm.DB, employeeID uint) (PayrollCalculationResponse,
 	resp := PayrollCalculationResponse{
 		EmployeeName:    healthResp.EmployeeName,
 		GrossSalary:     grossSalary,
+		TotalAllowance:  totalAllowance,
 		HealthInsurance: healthResp.EmployeeHealth,
 		Pension:         pensionResp.EmployeePension,
 		TotalDeductions: totalDeductions,


### PR DESCRIPTION
## 変更内容

- `AllowanceType`, `EmployeeAllowance` モデルを追加  
  - 手当の種類（歩合・固定など）を定義できるように
  - 従業員ごとの手当も個別に登録可能

- 給与計算（/payroll）に手当を反映  
  - 固定手当と歩合（= amount × rate）に対応  
  - 合計金額を `total_allowance` としてレスポンスに含めるように

- エンドポイント追加  
  - `POST /allowances/type` → 手当種別の登録  
  - `POST /employees/:id/allowances` → 従業員の手当を登録  
