### PR TITLE
従業員リストをログインアカウントの会社に制限

### DIFF
--- a/api/controllers/employee_controller.go
+++ b/api/controllers/employee_controller.go
@@ -10,8 +10,14 @@ import (
 )
 
 func GetEmployees(c *gin.Context) {
+	companyID, exists := c.Get("company_id")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "認証情報がありません"})
+		return
+	}
+
 	var employee []models.Employee
-	if err := db.DB.Find(&employee).Error; err != nil {
+	if err := db.DB.Where("company_id = ?", companyID).Find(&employee).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 	}
 	c.JSON(http.StatusOK, employee)

--- a/api/routes/allowances.go
+++ b/api/routes/allowances.go
@@ -3,10 +3,11 @@ package routes
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/t2469/labor-management-system.git/controllers"
+	"github.com/t2469/labor-management-system.git/middleware"
 )
 
 func addAllowanceRoutes(router *gin.Engine) {
-	allowances := router.Group("/allowances")
+	allowances := router.Group("/allowances", middleware.AuthMiddleware())
 	{
 		allowances.POST("type", controllers.CrateAllowanceType)
 		allowances.POST("", controllers.CreateEmployeeAllowance)

--- a/api/routes/auth_routes.go
+++ b/api/routes/auth_routes.go
@@ -14,6 +14,5 @@ func addAuthRoutes(router *gin.Engine) {
 	{
 		auth.POST("/logout", controllers.Logout)
 		auth.GET("/current_account", controllers.CurrentAccount)
-		auth.GET("/admin/employees", controllers.GetEmployees)
 	}
 }

--- a/api/routes/companies.go
+++ b/api/routes/companies.go
@@ -3,10 +3,11 @@ package routes
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/t2469/labor-management-system.git/controllers"
+	"github.com/t2469/labor-management-system.git/middleware"
 )
 
 func addCompanyRoutes(router *gin.Engine) {
-	companies := router.Group("/companies")
+	companies := router.Group("/companies", middleware.AuthMiddleware())
 	{
 		companies.POST("", controllers.CreateCompany)
 	}

--- a/api/routes/employees.go
+++ b/api/routes/employees.go
@@ -3,10 +3,11 @@ package routes
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/t2469/labor-management-system.git/controllers"
+	"github.com/t2469/labor-management-system.git/middleware"
 )
 
 func addEmployeeRoutes(router *gin.Engine) {
-	employees := router.Group("/employees")
+	employees := router.Group("/employees", middleware.AuthMiddleware())
 	{
 		employees.GET("", controllers.GetEmployees)
 		employees.GET("/:id", controllers.GetEmployee)


### PR DESCRIPTION
## 変更内容
- **従業員一覧 API のフィルタリング:**  
  - `GetEmployees` 関数内で、認証ミドルウェアから取得した `company_id` を用い、`WHERE company_id = ?` 条件で従業員データをフィルタリングするように変更。
- **認証保護:**
  - 手当作成、給与計算などの一部エンドポイントに認証ミドルウェアを追加し、ログイン済みユーザーのみに制限。

