### PR TITLE
デプロイ構成の整備（ECS, ALB, RDS, S3, CloudFront）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 .vscode/
 
 .env
-*.env
+*.env.*
 
 **/.terraform/*
 *.tfstate

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ override.tf.json
 terraform.rc
 
 api/tmp/
+infra/deploy_api.sh

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -11,8 +11,12 @@ type Config struct {
 }
 
 func LoadEnv() *Config {
-	if err := godotenv.Load(); err != nil {
-		log.Println("No .env file found")
+	if os.Getenv("GO_ENV") != "production" {
+		if err := godotenv.Load(); err != nil {
+			log.Println("No .env file found")
+		}
+	} else {
+		log.Println("Production mode detected. Skipping loading .env file.")
 	}
 
 	allowedOrigin := os.Getenv("ALLOWED_ORIGIN")

--- a/api/db/db.go
+++ b/api/db/db.go
@@ -19,7 +19,13 @@ func InitDB() {
 	password := os.Getenv("DB_PASSWORD")
 	dbname := os.Getenv("DB_NAME")
 
-	dsn := fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%s sslmode=disable TimeZone=Asia/Tokyo", host, user, password, dbname, port)
+	sslmode := "disable"
+	if os.Getenv("GO_ENV") == "production" {
+		sslmode = "require"
+	}
+
+	dsn := fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%s sslmode=%s TimeZone=Asia/Tokyo",
+		host, user, password, dbname, port, sslmode)
 
 	newLogger := logger.New(
 		log.New(os.Stdout, "\r\n", log.LstdFlags),

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.90.1"
+  constraints = "~> 5.90.0"
+  hashes = [
+    "h1:UOHmE27LtoyisllsyLEb+10+wpvHDgXBPYdMn5kKfdA=",
+    "zh:0d6179ec7c086049fd2f2d4cb2680edd238083ea7119e19c64921b2af395e1df",
+    "zh:208155e7d989941506deadabbd06159fac44fbddd557657b941d2ba0679ba9ce",
+    "zh:5adca7faa3c2031a9d6e8e3415c78160ae0bad6f568ef612b3201b12e29aa515",
+    "zh:81361ab0c3dee037d8e8a4dcf23d97d7392d7f00832b57d6c0fe8efbc8755589",
+    "zh:85b28e3ffe5e2f6a6640bf8ee544d6bb1dc1716d8c446927436ddd83b92ce0ae",
+    "zh:85e38aa50a4e16c1bf10eea7b35fac87fd0bc46cf8b68b7986f4041b69edf893",
+    "zh:9709b10fcb6e36c4347de1c26784209351865342a759f4b83a05e6e4e0db401f",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a62d5b7c7af67a2e4866899a405e2f6b82e85fd808b294f3704bdcb20fd640ac",
+    "zh:a84e56d4b4707e70c4322736171493e69f227de016649e0261b121695b6dea21",
+    "zh:a8c493907a4e0cf4a57b29a8695a6ca517407ff0b68b3005e39ad682606307e8",
+    "zh:c1938aaccc47c0723ae58c4a3a29fc0e114debeb251d4cd1fe8914d09a373615",
+    "zh:d57a0c8084c0982ce4b0dcd39afe3c4d64a6ed9729d3599a765611e5fcab45e9",
+    "zh:f2f21480e0ea5b58a14d285428f539ceedc38e317904272f4b4917130c49e549",
+    "zh:f6880a07727ed6698c46e9634b7e0438ebae7a0365a6eb98586d3d6465ae10be",
+  ]
+}

--- a/infra/acm.tf
+++ b/infra/acm.tf
@@ -12,14 +12,58 @@ resource "aws_acm_certificate" "api_cert" {
 }
 
 resource "aws_route53_record" "api_cert_validation" {
-  name    = tolist(aws_acm_certificate.api_cert.domain_validation_options)[0].resource_record_name
-  type    = tolist(aws_acm_certificate.api_cert.domain_validation_options)[0].resource_record_type
-  zone_id = data.aws_route53_zone.primary.zone_id
-  records = [tolist(aws_acm_certificate.api_cert.domain_validation_options)[0].resource_record_value]
-  ttl     = 60
+  for_each = {
+    for dvo in aws_acm_certificate.api_cert.domain_validation_options :
+    dvo.domain_name => dvo
+  }
+
+  allow_overwrite = true
+  name            = each.value.resource_record_name
+  type            = each.value.resource_record_type
+  zone_id         = data.aws_route53_zone.primary.zone_id
+  records = [each.value.resource_record_value]
+  ttl             = 60
 }
 
 resource "aws_acm_certificate_validation" "api_cert_validation" {
-  certificate_arn = aws_acm_certificate.api_cert.arn
-  validation_record_fqdns = [aws_route53_record.api_cert_validation.fqdn]
+  certificate_arn         = aws_acm_certificate.api_cert.arn
+  validation_record_fqdns = [
+    for record in aws_route53_record.api_cert_validation : record.fqdn
+  ]
+}
+
+resource "aws_acm_certificate" "frontend_cert" {
+  provider          = aws.us_east_1
+  domain_name       = "${var.frontend_subdomain}.${var.root_domain}"
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    Project = var.project_name
+  }
+}
+
+resource "aws_route53_record" "frontend_cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.frontend_cert.domain_validation_options :
+    dvo.domain_name => dvo
+  }
+
+  allow_overwrite = true
+  name            = each.value.resource_record_name
+  type            = each.value.resource_record_type
+  zone_id         = data.aws_route53_zone.primary.zone_id
+  records = [each.value.resource_record_value]
+  ttl             = 60
+}
+
+resource "aws_acm_certificate_validation" "frontend_cert_validation" {
+  provider                = aws.us_east_1
+  certificate_arn         = aws_acm_certificate.frontend_cert.arn
+  validation_record_fqdns = [
+    for record in aws_route53_record.frontend_cert_validation : record.fqdn
+  ]
 }

--- a/infra/acm.tf
+++ b/infra/acm.tf
@@ -1,0 +1,25 @@
+resource "aws_acm_certificate" "api_cert" {
+  domain_name       = "${var.api_subdomain}.${var.root_domain}"
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    Project = var.project_name
+  }
+}
+
+resource "aws_route53_record" "api_cert_validation" {
+  name    = tolist(aws_acm_certificate.api_cert.domain_validation_options)[0].resource_record_name
+  type    = tolist(aws_acm_certificate.api_cert.domain_validation_options)[0].resource_record_type
+  zone_id = data.aws_route53_zone.primary.zone_id
+  records = [tolist(aws_acm_certificate.api_cert.domain_validation_options)[0].resource_record_value]
+  ttl     = 60
+}
+
+resource "aws_acm_certificate_validation" "api_cert_validation" {
+  certificate_arn = aws_acm_certificate.api_cert.arn
+  validation_record_fqdns = [aws_route53_record.api_cert_validation.fqdn]
+}

--- a/infra/alb.tf
+++ b/infra/alb.tf
@@ -1,0 +1,78 @@
+resource "aws_lb" "app_alb" {
+  name               = "${var.project_name}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups = [aws_security_group.alb_sg.id]
+  subnets = [aws_subnet.public_a.id, aws_subnet.public_c.id]
+
+  tags = {
+    Name    = "${var.project_name}-alb"
+    Project = var.project_name
+  }
+}
+
+resource "aws_security_group" "alb_sg" {
+  name        = "${var.project_name}-alb-sg"
+  description = "Security group for ALB"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port = 80
+    to_port   = 80
+    protocol  = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 443
+    to_port   = 443
+    protocol  = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name    = "${var.project_name}-alb-sg"
+    Project = var.project_name
+  }
+}
+
+resource "aws_lb_target_group" "api_tg" {
+  name        = "${var.project_name}-api-tg"
+  port        = 8080
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = aws_vpc.main.id
+
+  health_check {
+    path                = "/"
+    protocol            = "HTTP"
+    matcher             = "200"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+  }
+
+  tags = {
+    Name    = "${var.project_name}-api-tg"
+    Project = var.project_name
+  }
+}
+
+resource "aws_lb_listener" "api_listener" {
+  load_balancer_arn = aws_lb.app_alb.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.api_tg.arn
+  }
+}

--- a/infra/alb.tf
+++ b/infra/alb.tf
@@ -72,6 +72,23 @@ resource "aws_lb_listener" "api_listener" {
   protocol          = "HTTP"
 
   default_action {
+    type = "redirect"
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb_listener" "api_https_listener" {
+  load_balancer_arn = aws_lb.app_alb.arn
+  port              = 443
+  protocol          = "HTTPS"
+
+  certificate_arn = aws_acm_certificate_validation.api_cert_validation.certificate_arn
+
+  default_action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.api_tg.arn
   }

--- a/infra/cloudwatch.tf
+++ b/infra/cloudwatch.tf
@@ -1,0 +1,4 @@
+resource "aws_cloudwatch_log_group" "ecs_api_log_group" {
+  name              = "/ecs/${var.project_name}-api"
+  retention_in_days = 7
+}

--- a/infra/ecr.tf
+++ b/infra/ecr.tf
@@ -1,0 +1,12 @@
+resource "aws_ecr_repository" "api_repo" {
+  name = "${var.project_name}-api"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    Name    = "${var.project_name}-api"
+    Project = var.project_name
+  }
+}

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -75,6 +75,14 @@ resource "aws_ecs_task_definition" "api_task" {
         { name = "JWT_SECRET", value = var.jwt_secret },
         { name = "ALLOWED_ORIGIN", value = var.allowed_origin }
       ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = "/ecs/${var.project_name}-api"
+          "awslogs-region"        = var.aws_region
+          "awslogs-stream-prefix" = "api"
+        }
+      }
     }
   ])
 

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -142,7 +142,7 @@ resource "aws_ecs_service" "api_service" {
     container_port   = 8080
   }
 
-  depends_on = [aws_lb_listener.api_listener]
+  depends_on = [aws_lb_listener.api_https_listener]
 
   tags = {
     Project = var.project_name

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -68,7 +68,7 @@ resource "aws_ecs_task_definition" "api_task" {
       environment = [
         { name = "MYSQL_USER", value = var.db_username },
         { name = "MYSQL_PASSWORD", value = var.db_password },
-        # { name = "MYSQL_HOST", value = aws_db_instance.db.address },
+        { name = "MYSQL_HOST", value = aws_db_instance.db.address },
         { name = "MYSQL_PORT", value = "3306" },
         { name = "MYSQL_DATABASE", value = var.db_name },
         { name = "GO_ENV", value = "production" },

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -54,7 +54,7 @@ resource "aws_ecs_task_definition" "api_task" {
   container_definitions = jsonencode([
     {
       name      = "api"
-      image     = aws_ecr_repository.api_repo.repository_url
+      image     = "${aws_ecr_repository.api_repo.repository_url}:${var.image_tag}"
       cpu       = 256
       memory    = 512
       essential = true

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -66,11 +66,11 @@ resource "aws_ecs_task_definition" "api_task" {
         }
       ]
       environment = [
-        { name = "MYSQL_USER", value = var.db_username },
-        { name = "MYSQL_PASSWORD", value = var.db_password },
-        { name = "MYSQL_HOST", value = aws_db_instance.db.address },
-        { name = "MYSQL_PORT", value = "3306" },
-        { name = "MYSQL_DATABASE", value = var.db_name },
+        { name = "DB_USER", value = var.db_username },
+        { name = "DB_PASSWORD", value = var.db_password },
+        { name = "DB_HOST", value = aws_db_instance.db.address },
+        { name = "DB_PORT", value = "5432" },
+        { name = "DB_NAME", value = var.db_name },
         { name = "GO_ENV", value = "production" },
         { name = "JWT_SECRET", value = var.jwt_secret },
         { name = "ALLOWED_ORIGIN", value = var.allowed_origin }

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -1,0 +1,142 @@
+resource "aws_ecs_cluster" "api_cluster" {
+  name = "${var.project_name}-cluster"
+
+  tags = {
+    Name    = "${var.project_name}-cluster"
+    Project = var.project_name
+  }
+}
+
+resource "aws_iam_role" "ecs_execution_role" {
+  name = "${var.project_name}-ecs-execution-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = { Service = "ecs-tasks.amazonaws.com" }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_execution_role_policy" {
+  role       = aws_iam_role.ecs_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role" "ecs_task_role" {
+  name = "${var.project_name}-ecs-task-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = { Service = "ecs-tasks.amazonaws.com" }
+      }
+    ]
+  })
+}
+
+resource "aws_ecs_task_definition" "api_task" {
+  family             = "${var.project_name}-api-task"
+  network_mode       = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                = "256"
+  memory             = "512"
+  execution_role_arn = aws_iam_role.ecs_execution_role.arn
+  task_role_arn      = aws_iam_role.ecs_task_role.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "api"
+      image     = aws_ecr_repository.api_repo.repository_url
+      cpu       = 256
+      memory    = 512
+      essential = true
+      portMappings = [
+        {
+          containerPort = 8080,
+          hostPort      = 8080,
+          protocol      = "tcp"
+        }
+      ]
+      environment = [
+        { name = "MYSQL_USER", value = var.db_username },
+        { name = "MYSQL_PASSWORD", value = var.db_password },
+        # { name = "MYSQL_HOST", value = aws_db_instance.db.address },
+        { name = "MYSQL_PORT", value = "3306" },
+        { name = "MYSQL_DATABASE", value = var.db_name },
+        { name = "GO_ENV", value = "production" },
+        { name = "JWT_SECRET", value = var.jwt_secret },
+        { name = "ALLOWED_ORIGIN", value = var.allowed_origin }
+      ]
+    }
+  ])
+
+  tags = {
+    Project = var.project_name
+  }
+}
+
+resource "aws_security_group" "api_service_sg" {
+  name        = "${var.project_name}-api-sg"
+  description = "Security group for ECS API service"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port = 8080
+    to_port   = 8080
+    protocol  = "tcp"
+    security_groups = [aws_security_group.alb_sg.id]
+  }
+
+  ingress {
+    from_port = 80
+    to_port   = 80
+    protocol  = "tcp"
+    security_groups = [aws_security_group.alb_sg.id]
+  }
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name    = "${var.project_name}-api-sg"
+    Project = var.project_name
+  }
+}
+
+resource "aws_ecs_service" "api_service" {
+  name            = "${var.project_name}-api-service"
+  cluster         = aws_ecs_cluster.api_cluster.id
+  task_definition = aws_ecs_task_definition.api_task.arn
+  launch_type     = "FARGATE"
+  desired_count   = 1
+
+  network_configuration {
+    subnets = [aws_subnet.private_a.id, aws_subnet.private_c.id]
+    security_groups = [aws_security_group.api_service_sg.id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.api_tg.arn
+    container_name   = "api"
+    container_port   = 8080
+  }
+
+  depends_on = [aws_lb_listener.api_listener]
+
+  tags = {
+    Project = var.project_name
+  }
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = "~> 1.11.1"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.90.0"
+    }
+  }
+}

--- a/infra/nat.tf
+++ b/infra/nat.tf
@@ -1,0 +1,61 @@
+resource "aws_security_group" "nat_sg" {
+  name        = "${var.project_name}-nat-sg"
+  description = "Security group for NAT instance"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = [var.private_subnet_cidr_a, var.private_subnet_cidr_c]
+  }
+  ingress {
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+    cidr_blocks = [var.admin_ip]
+  }
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+data "aws_ami" "nat" {
+  most_recent = true
+  owners = ["amazon"]
+
+  filter {
+    name = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+}
+
+resource "aws_instance" "nat" {
+  ami                         = data.aws_ami.nat.id
+  instance_type               = "t2.micro"
+  subnet_id                   = aws_subnet.public_a.id
+  associate_public_ip_address = true
+  security_groups = [aws_security_group.nat_sg.id]
+  key_name                    = var.key_pair_name
+  source_dest_check           = false
+
+  user_data = <<-EOF
+    #!/bin/bash
+    echo 1 > /proc/sys/net/ipv4/ip_forward
+    echo "net.ipv4.ip_forward = 1" >> /etc/sysctl.conf
+    sysctl -p
+    iptables -t nat -A POSTROUTING -o eth0 -s ${var.private_subnet_cidr_a} -j MASQUERADE
+    iptables -t nat -A POSTROUTING -o eth0 -s ${var.private_subnet_cidr_c} -j MASQUERADE
+    yum install -y iptables-services
+    service iptables save
+    service iptables restart
+  EOF
+
+  tags = {
+    Name    = "${var.project_name}-nat"
+    Project = var.project_name
+  }
+}

--- a/infra/network.tf
+++ b/infra/network.tf
@@ -1,0 +1,114 @@
+resource "aws_vpc" "main" {
+  cidr_block = var.vpc_cidr
+  enable_dns_support = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name    = "${var.project_name}-vpc"
+    Project = var.project_name
+  }
+}
+
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name    = "${var.project_name}-igw"
+    Project = var.project_name
+  }
+}
+
+resource "aws_subnet" "public_a" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_cidr_a
+  availability_zone       = "${var.aws_region}a"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name    = "${var.project_name}-public-a"
+    Project = var.project_name
+  }
+}
+
+resource "aws_subnet" "public_c" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_cidr_c
+  availability_zone       = "${var.aws_region}c"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name    = "${var.project_name}-public-c"
+    Project = var.project_name
+  }
+}
+
+resource "aws_subnet" "private_a" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.private_subnet_cidr_a
+  availability_zone = "${var.aws_region}a"
+
+  tags = {
+    Name    = "${var.project_name}-private-a"
+    Project = var.project_name
+  }
+}
+
+resource "aws_subnet" "private_c" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.private_subnet_cidr_c
+  availability_zone = "${var.aws_region}c"
+
+  tags = {
+    Name    = "${var.project_name}-private-c"
+    Project = var.project_name
+  }
+}
+
+resource "aws_route_table" "public_rt" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.igw.id
+  }
+
+  tags = {
+    Name    = "${var.project_name}-public-rt"
+    Project = var.project_name
+  }
+}
+
+resource "aws_route_table_association" "public_assoc_a" {
+  subnet_id      = aws_subnet.public_a.id
+  route_table_id = aws_route_table.public_rt.id
+}
+
+resource "aws_route_table_association" "public_assoc_c" {
+  subnet_id      = aws_subnet.public_c.id
+  route_table_id = aws_route_table.public_rt.id
+}
+
+resource "aws_route_table" "private_rt" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name    = "${var.project_name}-private-rt"
+    Project = var.project_name
+  }
+}
+
+resource "aws_route" "private_nat_route" {
+  route_table_id         = aws_route_table.private_rt.id
+  destination_cidr_block = "0.0.0.0/0"
+  network_interface_id   = aws_instance.nat.primary_network_interface_id
+}
+
+resource "aws_route_table_association" "private_assoc_a" {
+  subnet_id      = aws_subnet.private_a.id
+  route_table_id = aws_route_table.private_rt.id
+}
+
+resource "aws_route_table_association" "private_assoc_c" {
+  subnet_id      = aws_subnet.private_c.id
+  route_table_id = aws_route_table.private_rt.id
+}

--- a/infra/output.tf
+++ b/infra/output.tf
@@ -3,17 +3,22 @@ output "vpc_id" {
   value       = aws_vpc.main.id
 }
 
-# output "ecs_cluster_id" {
-#   description = "ID of the created ECS Cluster"
-#   value       = aws_ecs_cluster.main.id
-# }
-#
-# output "alb_dns_name" {
-#   description = "DNS name of the Application Load Balancer"
-#   value       = aws_lb.app_alb.dns_name
-# }
-#
-# output "rds_endpoint" {
-#   description = "Endpoint of the RDS instance"
-#   value       = aws_db_instance.db.address
-# }
+output "ecs_cluster_id" {
+  description = "ID of the created ECS Cluster"
+  value       = aws_ecs_cluster.api_cluster.id
+}
+
+output "alb_dns_name" {
+  description = "DNS name of the Application Load Balancer"
+  value       = aws_lb.app_alb.dns_name
+}
+
+output "rds_endpoint" {
+  description = "Endpoint of the RDS instance"
+  value       = aws_db_instance.db.address
+}
+
+output "cloudfront_domain_name" {
+  description = "Domain name of the CloudFront Distribution"
+  value       = aws_cloudfront_distribution.frontend_distribution.domain_name
+}

--- a/infra/output.tf
+++ b/infra/output.tf
@@ -1,0 +1,19 @@
+output "vpc_id" {
+  description = "ID of the created VPC"
+  value       = aws_vpc.main.id
+}
+
+# output "ecs_cluster_id" {
+#   description = "ID of the created ECS Cluster"
+#   value       = aws_ecs_cluster.main.id
+# }
+#
+# output "alb_dns_name" {
+#   description = "DNS name of the Application Load Balancer"
+#   value       = aws_lb.app_alb.dns_name
+# }
+#
+# output "rds_endpoint" {
+#   description = "Endpoint of the RDS instance"
+#   value       = aws_db_instance.db.address
+# }

--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.aws_region
+}

--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -1,3 +1,8 @@
 provider "aws" {
   region = var.aws_region
 }
+
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}

--- a/infra/rds.tf
+++ b/infra/rds.tf
@@ -1,0 +1,59 @@
+resource "aws_db_subnet_group" "rds_subnet_group" {
+  name = "${var.project_name}-rds-subnet"
+  subnet_ids = [
+    aws_subnet.private_a.id,
+    aws_subnet.private_c.id
+  ]
+
+  tags = {
+    Name    = "${var.project_name}-rds-subnet"
+    Project = var.project_name
+  }
+}
+
+resource "aws_security_group" "rds_sg" {
+  name        = "${var.project_name}-rds-sg"
+  description = "Security group for RDS instance"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port = 5432
+    to_port   = 5432
+    protocol  = "tcp"
+    security_groups = [aws_security_group.api_service_sg.id]
+  }
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name    = "${var.project_name}-rds-sg"
+    Project = var.project_name
+  }
+}
+
+resource "aws_db_instance" "db" {
+  identifier           = "${var.project_name}-postgres"
+  engine               = "postgres"
+  engine_version       = "17"
+  instance_class       = "db.t3.micro"
+  allocated_storage    = 20
+  storage_type         = "gp2"
+  username             = var.db_username
+  password             = var.db_password
+  db_name              = var.db_name
+  publicly_accessible  = false
+  vpc_security_group_ids = [aws_security_group.rds_sg.id]
+  db_subnet_group_name = aws_db_subnet_group.rds_subnet_group.name
+
+  skip_final_snapshot = true
+
+  tags = {
+    Name    = "${var.project_name}-postgres"
+    Project = var.project_name
+  }
+}

--- a/infra/route53.tf
+++ b/infra/route53.tf
@@ -1,0 +1,28 @@
+data "aws_route53_zone" "primary" {
+  name         = var.root_domain
+  private_zone = false
+}
+
+resource "aws_route53_record" "attendance_frontend" {
+  zone_id = data.aws_route53_zone.primary.zone_id
+  name    = "${var.frontend_subdomain}.${var.root_domain}"
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.frontend_distribution.domain_name
+    zone_id                = "Z2FDTNDATAQYW2"
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "api_attendance" {
+  zone_id = data.aws_route53_zone.primary.zone_id
+  name    = "${var.api_subdomain}.${var.root_domain}"
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.app_alb.dns_name
+    zone_id                = aws_lb.app_alb.zone_id
+    evaluate_target_health = false
+  }
+}

--- a/infra/s3_cloudfront.tf
+++ b/infra/s3_cloudfront.tf
@@ -43,6 +43,8 @@ resource "aws_s3_bucket_policy" "frontend_bucket_policy" {
 }
 
 resource "aws_cloudfront_distribution" "frontend_distribution" {
+  aliases = ["${var.frontend_subdomain}.${var.root_domain}"]
+
   origin {
     domain_name = aws_s3_bucket.frontend_bucket.bucket_regional_domain_name
     origin_id   = "S3-${aws_s3_bucket.frontend_bucket.id}"

--- a/infra/s3_cloudfront.tf
+++ b/infra/s3_cloudfront.tf
@@ -1,0 +1,93 @@
+resource "aws_s3_bucket" "frontend_bucket" {
+  bucket = "${var.project_name}-frontend"
+
+  tags = {
+    Name    = "${var.project_name}-frontend"
+    Project = var.project_name
+  }
+}
+
+resource "aws_s3_bucket_website_configuration" "frontend_bucket_website" {
+  bucket = aws_s3_bucket.frontend_bucket.id
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "error.html"
+  }
+}
+
+resource "aws_cloudfront_origin_access_identity" "oai" {
+  comment = "OAI for ${var.project_name} frontend"
+}
+
+resource "aws_s3_bucket_policy" "frontend_bucket_policy" {
+  bucket = aws_s3_bucket.frontend_bucket.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid    = "GrantCloudFrontAccess",
+        Effect = "Allow",
+        Principal = {
+          AWS = aws_cloudfront_origin_access_identity.oai.iam_arn
+        },
+        Action   = "s3:GetObject",
+        Resource = "${aws_s3_bucket.frontend_bucket.arn}/*"
+      }
+    ]
+  })
+}
+
+resource "aws_cloudfront_distribution" "frontend_distribution" {
+  origin {
+    domain_name = aws_s3_bucket.frontend_bucket.bucket_regional_domain_name
+    origin_id   = "S3-${aws_s3_bucket.frontend_bucket.id}"
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.oai.cloudfront_access_identity_path
+    }
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "${var.project_name} frontend distribution"
+  default_root_object = "index.html"
+
+  default_cache_behavior {
+    allowed_methods = ["GET", "HEAD", "OPTIONS"]
+    cached_methods = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "S3-${aws_s3_bucket.frontend_bucket.id}"
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+    minimum_protocol_version       = "TLSv1"
+  }
+
+  tags = {
+    Name    = "${var.project_name}-frontend"
+    Project = var.project_name
+  }
+}

--- a/infra/s3_cloudfront.tf
+++ b/infra/s3_cloudfront.tf
@@ -75,6 +75,20 @@ resource "aws_cloudfront_distribution" "frontend_distribution" {
     max_ttl                = 86400
   }
 
+  custom_error_response {
+    error_code            = 403
+    response_page_path    = "/index.html"
+    response_code         = 200
+    error_caching_min_ttl = 0
+  }
+
+  custom_error_response {
+    error_code            = 404
+    response_page_path    = "/index.html"
+    response_code         = 200
+    error_caching_min_ttl = 0
+  }
+
   restrictions {
     geo_restriction {
       restriction_type = "none"
@@ -83,7 +97,7 @@ resource "aws_cloudfront_distribution" "frontend_distribution" {
 
   viewer_certificate {
     cloudfront_default_certificate = true
-    minimum_protocol_version       = "TLSv1"
+    minimum_protocol_version       = "TLSv1.2_2018"
   }
 
   tags = {

--- a/infra/s3_cloudfront.tf
+++ b/infra/s3_cloudfront.tf
@@ -96,8 +96,9 @@ resource "aws_cloudfront_distribution" "frontend_distribution" {
   }
 
   viewer_certificate {
-    cloudfront_default_certificate = true
-    minimum_protocol_version       = "TLSv1.2_2018"
+    acm_certificate_arn      = aws_acm_certificate_validation.frontend_cert_validation.certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2019"
   }
 
   tags = {

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -75,3 +75,8 @@ variable "jwt_secret" {
   type        = string
   sensitive   = true
 }
+
+variable "allowed_origin" {
+  type        = string
+  description = "Frontend URL used by the backend service"
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,77 @@
+variable "project_name" {
+  description = "project_name"
+  type        = string
+  default     = "labor-manegment"
+}
+
+variable "aws_region" {
+  description = "AWS region to deploy resources"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "public_subnet_cidr_a" {
+  description = "CIDR block for the public subnet in AZ a"
+  type        = string
+  default     = "10.0.1.0/24"
+}
+
+variable "public_subnet_cidr_c" {
+  description = "CIDR block for the public subnet in AZ b"
+  type        = string
+  default     = "10.0.3.0/24"
+}
+
+variable "private_subnet_cidr_a" {
+  description = "CIDR block for the private subnet in AZ a"
+  type        = string
+  default     = "10.0.2.0/24"
+}
+
+variable "private_subnet_cidr_c" {
+  description = "CIDR block for the private subnet in AZ c"
+  type        = string
+  default     = "10.0.4.0/24"
+}
+
+variable "key_pair_name" {
+  description = "EC2 key pair name for NAT instance"
+  type        = string
+  sensitive   = true
+}
+
+variable "db_username" {
+  description = "Username for RDS database"
+  type        = string
+  sensitive   = true
+}
+
+variable "db_password" {
+  description = "Password for RDS database"
+  type        = string
+  sensitive   = true
+}
+
+variable "db_name" {
+  description = "Database name for RDS"
+  type        = string
+  sensitive   = true
+}
+
+variable "admin_ip" {
+  description = "Administrator's public IP address"
+  type        = string
+  sensitive   = true
+}
+
+variable "jwt_secret" {
+  description = "JWT secret key"
+  type        = string
+  sensitive   = true
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -10,6 +10,24 @@ variable "aws_region" {
   default     = "ap-northeast-1"
 }
 
+variable "root_domain" {
+  description = "The root domain in Route53"
+  type        = string
+  default     = "t2469.com"
+}
+
+variable "frontend_subdomain" {
+  description = "Subdomain for the frontend"
+  type        = string
+  default     = "attendance"
+}
+
+variable "api_subdomain" {
+  description = "Subdomain for API ALB"
+  type        = string
+  default     = "api.attendance"
+}
+
 variable "vpc_cidr" {
   description = "CIDR block for the VPC"
   type        = string

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -80,3 +80,8 @@ variable "allowed_origin" {
   type        = string
   description = "Frontend URL used by the backend service"
 }
+
+variable "image_tag" {
+  description = "Docker image tag for versioning the api image"
+  type        = string
+}


### PR DESCRIPTION
## 変更内容

### 環境設定の変更:
* [`api/config/config.go`](diffhunk://#diff-7f88f1945fb732d6ac18c0a4b3adfd6bec6f337538050f52d4a52db2e1d65b47R14-R20): 本番モードでは `.env` ファイルの読み込みをスキップするロジックを追加
* [`api/db/db.go`](diffhunk://#diff-0133ff04366cb6dfb954c552b68c21bf563ded008e5a5b2a4d513e7426cd61f0L22-R28): 本番環境で SSL モードを使用するようにデータベース接続を構成

### Terraform および AWS リソース構成:
* [`infra/main.tf`](diffhunk://#diff-c4edee4039d22cfe2fd0d1ef214e7eba022aa85b29dd5677f4485f60e5b7a668R1-R9): 必須の Terraform バージョンと AWS プロバイダーを定義
* [`infra/provider.tf`](diffhunk://#diff-41f8c2a70e267281aa1bca58cc75bda58efea111a2e3b547d971441c5c08be10R1-R8): 異なるリージョン用に AWS プロバイダーを構成

### AWS インフラ構築:
* [`infra/network.tf`](diffhunk://#diff-efaf250ad3c06723986bfd3311da2d3aa8e3da72f9836910cfb8b89be0be6b8eR1-R114): VPC、サブネット、インターネットゲートウェイ、ルートテーブルを作成
* [`infra/nat.tf`](diffhunk://#diff-245e14d4a717509ceefe2d7230af1b2ddd3c6284dfe3a534e1a72af2a22a2602R1-R61): IP フォワーディング用のユーザーデータとセキュリティグループを設定した NAT インスタンスを構築

### ECS および RDS 構成:
* [`infra/ecs.tf`](diffhunk://#diff-89498805c3e11f56b65cc7c20eb36471b52a76f75794dc3664f05023dc18dddeR1-R150): セキュリティグループと IAM ロールを含む ECS クラスター、タスク定義、サービスを構成
* [`infra/rds.tf`](diffhunk://#diff-cadec06786a8f37c714d8dcae6888314f66813933fae92ee578640b014e44d67R1-R59): サブネットグループとセキュリティグループを含む RDS インスタンスを設定

### その他の AWS リソース:
* [`infra/s3_cloudfront.tf`](diffhunk://#diff-25404b02ce69f51c4314cd14fb87750f65bd38def8136004d30d959e288abdb8R1-R110): フロントエンド用の S3 バケット、CloudFront ディストリビューション、関連ポリシーを構成
* [`infra/alb.tf`](diffhunk://#diff-603927c39f0a786128a0ea35afdcbd6406c38985a6fd7a3714daee3b2d4d1620R1-R95): アプリケーションロードバランサー、ターゲットグループ、リスナーを作成
* [`infra/acm.tf`](diffhunk://#diff-9f9f0755e4c6b71b6875d18a292f21491e08634f60cb186b8a6ad83698d18c81R1-R69): API およびフロントエンド用の ACM 証明書と検証レコードを構成
* [`infra/cloudwatch.tf`](diffhunk://#diff-55977aa466cdae5cc9cbb85fc69cffeb6c66eada598412ec0fd715ab870351fcR1-R4): ECS API ログ用の CloudWatch ロググループを作成
* [`infra/ecr.tf`](diffhunk://#diff-6aee8bf71c4e3ac9f9156a94137d6cb47c1180cf191a88954541d951fb51e933R1-R12): API イメージ用の ECR リポジトリを作成
* [`infra/route53.tf`](diffhunk://#diff-73b36541a37de3dc620856780a368793897145d13769d638746731636e0780cdR1-R28): API およびフロントエンドのドメイン用に Route 53 レコードを設定
* [`infra/output.tf`](diffhunk://#diff-0ea835146507d005406aa748d982faf22bcc9f7826505f08ac7105b6ff60a334R1-R24): VPC ID、ECS クラスター ID、ALB の DNS 名などの AWS リソース出力を定義
