### PR TITLE
TablePlusでRDSへ接続できるように構成を調整

### DIFF
--- a/infra/rds.tf
+++ b/infra/rds.tf
@@ -20,7 +20,7 @@ resource "aws_security_group" "rds_sg" {
     from_port = 5432
     to_port   = 5432
     protocol  = "tcp"
-    security_groups = [aws_security_group.api_service_sg.id]
+    security_groups = [aws_security_group.api_service_sg.id, aws_security_group.bastion_sg.id]
   }
 
   egress {
@@ -54,6 +54,46 @@ resource "aws_db_instance" "db" {
 
   tags = {
     Name    = "${var.project_name}-postgres"
+    Project = var.project_name
+  }
+}
+
+resource "aws_security_group" "bastion_sg" {
+  name        = "${var.project_name}-bastion-sg"
+  description = "Security group for Bastion host"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+    cidr_blocks = [var.admin_ip]
+  }
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name    = "${var.project_name}-bastion-sg"
+    Project = var.project_name
+  }
+}
+
+resource "aws_instance" "bastion" {
+  ami           = "ami-0c3fd0f5d33134a76"
+  instance_type = "t2.micro"
+  subnet_id     = aws_subnet.public_a.id
+  vpc_security_group_ids = [aws_security_group.bastion_sg.id]
+
+  associate_public_ip_address = true
+  key_name                    = var.key_pair_name
+
+  tags = {
+    Name    = "${var.project_name}-bastion"
     Project = var.project_name
   }
 }


### PR DESCRIPTION
## 変更内容

### セキュリティグループの変更
- [`infra/rds.tf`](diffhunk://#diff-cadec06786a8f37c714d8dcae6888314f66813933fae92ee578640b014e44d67L23-R23):  
  RDS インスタンスのセキュリティグループに Bastion ホストのセキュリティグループを追加。

### 新しいリソースの追加

- [`infra/rds.tf`](diffhunk://#diff-cadec06786a8f37c714d8dcae6888314f66813933fae92ee578640b014e44d67R60-R99):  
  Bastion ホスト用の新しいセキュリティグループ（インバウンド／アウトバウンドルール付き）を追加。

- [`infra/rds.tf`](diffhunk://#diff-cadec06786a8f37c714d8dcae6888314f66813933fae92ee578640b014e44d67R60-R99):  
  上記セキュリティグループを適用した Bastion ホストインスタンスを新たに追加。
